### PR TITLE
⚡ Optimize calendar watcher performance

### DIFF
--- a/src/pages/main/components/calendar.vue
+++ b/src/pages/main/components/calendar.vue
@@ -591,11 +591,20 @@ watch(timeType, (newValue) => {
     }
 })
 
-watch(store.$state, (newValue) => {
-    calendarApi.value?.changeView(newValue.options.calendarType)
-    setBorderColor(convertRGBA(newValue.options.calendar.color))
-    setBackgroudColor(convertRGBA(newValue.options.calendar.background))
-    buttonType.value = newValue.options.calendar.buttonType
+watch(() => store.options.calendarType, (newValue) => {
+    calendarApi.value?.changeView(newValue)
+})
+
+watch(() => store.options.calendar.color, (newValue) => {
+    setBorderColor(convertRGBA(newValue))
+}, { deep: true })
+
+watch(() => store.options.calendar.background, (newValue) => {
+    setBackgroudColor(convertRGBA(newValue))
+}, { deep: true })
+
+watch(() => store.options.calendar.buttonType, (newValue) => {
+    buttonType.value = newValue
 })
 
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3112,7 +3112,7 @@ vue-tsc@^2.0.22:
     "@vue/language-core" "2.0.22"
     semver "^7.5.4"
 
-"vue@^2.6.14 || ^3.3.0", "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.11, vue@^3.2.0, vue@^3.2.25, vue@^3.4.31, vue@>=3.2.0, vue@3.4.31:
+"vue@^2.6.14 || ^3.3.0", "vue@^3.0.0-0 || ^2.6.0", vue@^3.0.11, vue@^3.2.0, vue@^3.2.25, vue@>=3.2.0, vue@3.4.31:
   version "3.4.31"
   resolved "https://registry.npmjs.org/vue/-/vue-3.4.31.tgz"
   integrity sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==


### PR DESCRIPTION
💡 **What:**
Refactored the single deep watcher on the entire store state in `src/pages/main/components/calendar.vue` into four specific watchers for:
- `store.options.calendarType`
- `store.options.calendar.color` (deep)
- `store.options.calendar.background` (deep)
- `store.options.calendar.buttonType`

🎯 **Why:**
The previous implementation used `watch(store.$state, ...)` which triggered all calendar update logic (changing view, resetting colors, etc.) whenever *any* property in the store changed, even unrelated ones like `refreshTime` or `calendarHeight`. This caused unnecessary computations and potential re-renders.

📊 **Measured Improvement:**
A benchmark script simulating the store and watchers showed:
- **Baseline:** Changing `refreshTime` (unrelated property) triggered 4 unnecessary function calls (`changeView`, `setBorderColor`, `setBackgroudColor`, `buttonType` update).
- **Optimized:** Changing `refreshTime` triggered **0** function calls.
- **Correctness:** Changing `calendarType` still correctly triggers `changeView`.

This change ensures that calendar updates only happen when relevant settings are modified.

---
*PR created automatically by Jules for task [6038466678942699575](https://jules.google.com/task/6038466678942699575) started by @LETS-BEE*