### PR TITLE
Fix parseCmdStr regex to handle escaped braces

### DIFF
--- a/src/plugin/fullcalendar-dayjs/index.js
+++ b/src/plugin/fullcalendar-dayjs/index.js
@@ -63,7 +63,7 @@ function createMomentFormatFunc(mom) {
 }
 
 function parseCmdStr(cmdStr) {
-    let parts = cmdStr.match(/^(.*?)\{(.*)\}(.*)$/); // TODO: lookbehinds for escape characters
+    let parts = cmdStr.match(/^(.*?)(?<!\\)\{(.*)(?<!\\)\}(.*)$/);
 
     if (parts) {
         let middle = parseCmdStr(parts[2]);


### PR DESCRIPTION
Updated `src/plugin/fullcalendar-dayjs/index.js` to correctly handle escaped curly braces in format strings using regex lookbehinds.Verified with a reproduction script.

---
*PR created automatically by Jules for task [18130029943879504930](https://jules.google.com/task/18130029943879504930) started by @LETS-BEE*